### PR TITLE
GH-4, solve compatibility with the official @vue/vue-cli-plugin-unit-…

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -1,14 +1,25 @@
 module.exports = (api, options) => {
   api.render('./template/default', options);
 
-  api.extendPackage({
-    devDependencies: {
+  // These dependencies always need to be added
+  const devDependencies = api.hasPlugin('unit-jest')
+    // If the official @vue/cli-plugin-unit-jest installed, then we can avoid installing jest and some related dependencies
+    // However since it still uses jest 23, the version of jest-puppeteer cannot be the last one
+    ? {
+      puppeteer: '^1.17.0',
+      'jest-puppeteer': '^3.9.0'
+    }
+    // The plugin isnt installed, so we can install latest jest as well as latest jest-puppeteer
+    : {
       jest: '^24.8.0',
-      'jest-puppeteer': '^4.2.0',
       'babel-jest': "^24.8.0",
       'babel-plugin-transform-es2015-modules-commonjs': '^6.26.2',
       puppeteer: '^1.17.0',
-    },
+      'jest-puppeteer': '^4.2.0',
+    };
+
+  api.extendPackage({
+    devDependencies,
     scripts: {
       'test:e2e': 'jest --config=jest.e2e.config.js --runInBand',
     },


### PR DESCRIPTION
Fixes GH-4 by checking whether `@vue/vue-cli-plugin-unit-jest` is also installed and in that case installing jest-puppeteer@3.9.0 instead of the latest one (since the unit-jest plugin still uses jest 23!)